### PR TITLE
Fix: Automatic relaod when CSV upload is complete

### DIFF
--- a/urlsaver/templates/index.html
+++ b/urlsaver/templates/index.html
@@ -151,8 +151,14 @@
 					data-bs-toggle="modal"
 					data-bs-target="#addUrlModal"
 					>
-					+ Add URLs
+					+ Add URL
 			</button>
+            <button
+                class="btn btn-outline-dark btn-sm"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#csvUploadCanvas">
+                + Import URLs via CSV
+            </button>
 			<button
 					class="btn btn-outline-dark btn-sm"
 					data-bs-toggle="offcanvas"
@@ -160,12 +166,6 @@
 					>
 					Activity
 			</button>
-            <button
-                class="btn btn-outline-dark btn-sm"
-                data-bs-toggle="offcanvas"
-                data-bs-target="#csvUploadCanvas">
-                + Add Links via CSV
-            </button>
 		</div>
 
 		<!-- Activity Offcanvas -->


### PR DESCRIPTION
 Automatic reload when imported URLs from .CSV files, planned targeted DOM update to prevent page relaods